### PR TITLE
Link handling improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,10 @@ module.exports = (apiUrl, apiKey, options = {}) => {
   async function * listPaginated (endpoint, parameters = {}) {
     try {
       let url = resolve(endpoint)
+      let qs = {
+        per_page: 100,
+        ...parameters
+      }
 
       while (url) {
         log(`Request GET ${url}`)
@@ -76,10 +80,7 @@ module.exports = (apiUrl, apiKey, options = {}) => {
           auth: {
             bearer: apiKey
           },
-          qs: {
-            per_page: 100,
-            ...parameters
-          },
+          qs,
           qsStringifyOptions: {
             arrayFormat: 'brackets'
           },
@@ -88,8 +89,8 @@ module.exports = (apiUrl, apiKey, options = {}) => {
 
         log(`Response from GET ${url}`)
         yield response.body
-
         url = response.headers && getNextUrl(response.headers.link)
+        qs = null
       }
     } catch (err) {
       throw removeToken(err)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3705,9 +3705,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
When following a url from a link header, the query string is already baked into the url itself. Thus we need to make sure not to pass a query string object to the request-promise call.

Also ran a `npm audit fix`, due to warnings and such 🤡 