### PR TITLE
Iteration to array

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ for await (let page of canvas.listPaginated('/courses')) {
 
 ```
 
-### Convert iterables to arrays with `.take()`
+### Convert iterables to arrays with `.toArray()`
 
-Both `list()` and `listPaginated()` return special versions of iterables with a `take()` method. Use it to convert the iterables to arrays:
+Both `list()` and `listPaginated()` return special versions of iterables with a `toArray()` method. Use it to convert the iterables to arrays:
 
 ``` javascript
-const courses = (await canvas.list('/courses').take())
+const courses = (await canvas.list('/courses').toArray())
   .filter(c => c.id < 100)
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,36 +32,44 @@ The builder function accepts three arguments:
 3. `options`. *optional* An object containing:
    - `log`. A function that will be called with logging messages. Default: empty function
 
-### Basic usage of `get()`, `list()` and `listPaginated()`
+### Get a single resource with `get()`
 
-Use `get()` to get a single resource
+Use `get()` to get a single resource. Get returns the whole response (not only its body)
 
 ``` js
-// This will return only the "first page".
-// Sometimes it's enough
-const courses = await canvas.get('/courses')
+const response = await canvas.get('/courses/1')
+const console.log(response.body.name)
 ```
 
-Use `list()` to get a list of resources and iterate through them. `list()` returns an async iterable that iterates for each element.
+### Get iterables with `list()` and `listPaginated()`
+
+Use `list()` to get an **iterable** of resources
 
 ``` js
-const courses = canvas.list('/courses')
-for await (let course of courses) {
+for await (let course of canvas.list('/courses')) {
   console.log(course.id)
 }
 ```
 
-Use `listPaginated()` to get a list of pages and iterate through them. `listPaginated()` returns an async iterable that iterates per page.
+Use `listPaginated()` to get an iterable of **pages**
 
 ```js
-const pages = canvas.listPaginated('/courses')
-
-for await (let page of pages) {
+for await (let page of canvas.listPaginated('/courses')) {
   // Each "page" is a list of courses
   console.log(page.length)
 }
 
 ```
+
+### Convert iterables to arrays with `.take()`
+
+Both `list()` and `listPaginated()` return special versions of iterables with a `take()` method. Use it to convert the iterables to arrays:
+
+``` javascript
+const courses = (await canvas.list('/courses').take())
+  .filter(c => c.id < 100)
+```
+
 
 ### Advanced usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Canvas API
+# Canvas API client
 
-NodeJS interface for making requests to the [Canvas LMS API](https://canvas.instructure.com/doc/api/)
+NodeJS HTTP client based on [Request-Promise](https://github.com/request/request-promise) for the [Canvas LMS API](https://canvas.instructure.com/doc/api/)
 
 [![Build Status](https://travis-ci.org/KTH/canvas-api.svg?branch=master)](https://travis-ci.org/KTH/canvas-api)
 
@@ -10,10 +10,9 @@ NodeJS interface for making requests to the [Canvas LMS API](https://canvas.inst
 Once you build a canvas instance, you get an object with only four methods:
 
 1. The low-level `requestUrl()` method to perform any request with any HTTP method
-2. Three high-level methods for doing GET requests:
-   - `get()` to perform a GET request
-   - `list()` to perform a GET request and iterate through the results
-   - `listPaginated()` like *list()* but for iterating through pages
+2. `get()` to perform a GET request
+3. `list()` to perform a GET request and iterate through the results. Works for paginated responses.
+4. `listPaginated()` like *list()* but for iterating through pages
 
 ### Build the Canvas instance
 
@@ -51,7 +50,7 @@ for await (let course of canvas.list('/courses')) {
 }
 ```
 
-Use `listPaginated()` to get an iterable of **pages**
+Use `listPaginated()` to get an iterable of **pages** (you won't need this almost never)
 
 ```js
 for await (let page of canvas.listPaginated('/courses')) {
@@ -83,7 +82,7 @@ const courses = await canvas.list('/courses', {enrollment_type: 'teacher'})
 const pages = await canvas.listPaginated('/courses', {enrollment_type: 'teacher'})
 ```
 
-### Low-level `requestUrl` (for non-GET requests)
+### `requestUrl` (for non-GET requests)
 
 The method returns a full response (including headers, statusCode...)
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const rp = require('request-promise')
+const augmentGenerator = require('./lib/augmentGenerator')
 
 function removeToken (err) {
   delete err.error
@@ -97,10 +98,12 @@ module.exports = (apiUrl, apiKey, options = {}) => {
     }
   }
 
+
+
   return {
     requestUrl,
     get,
-    list,
-    listPaginated
+    list: augmentGenerator(list),
+    listPaginated: augmentGenerator(listPaginated)
   }
 }

--- a/index.js
+++ b/index.js
@@ -98,8 +98,6 @@ module.exports = (apiUrl, apiKey, options = {}) => {
     }
   }
 
-
-
   return {
     requestUrl,
     get,

--- a/lib/augmentGenerator.js
+++ b/lib/augmentGenerator.js
@@ -2,7 +2,7 @@ module.exports = function augmentGenerator (generator) {
   return function (...args) {
     const iterable = generator(...args)
 
-    iterable.take = async function (count = Infinity) {
+    iterable.toArray = async function (count = Infinity) {
       const result = []
       const iterator = iterable[Symbol.asyncIterator]()
 

--- a/lib/augmentGenerator.js
+++ b/lib/augmentGenerator.js
@@ -1,0 +1,11 @@
+module.exports = function augmentGenerator (generator) {
+  return function (...args) {
+    const iterator = generator(...args)
+
+    iterator.take = async function () {
+      return 1
+    }
+
+    return iterator
+  }
+}

--- a/lib/augmentGenerator.js
+++ b/lib/augmentGenerator.js
@@ -1,17 +1,23 @@
-module.exports = function augmentGenerator (generator) {
-  return function (...args) {
-    const iterable = generator(...args)
+/**
+ * Converts a "normal generator" function to an "extended generator" function
+ *
+ * - A input (a normal generator) is a function that returns an
+ *   Iterable object.
+ * - The output (an "extended" generator) is a function that returns an
+ *   ExtendedIterable, which is like a normal Iterable but with extra methods.
+ */
+module.exports = (generator) => function extendedGenerator (...args) {
+  const iterable = generator(...args)
 
-    iterable.toArray = async function () {
-      const result = []
+  iterable.toArray = async function () {
+    const result = []
 
-      for await (const v of iterable) {
-        result.push(v)
-      }
-
-      return result
+    for await (const v of iterable) {
+      result.push(v)
     }
 
-    return iterable
+    return result
   }
+
+  return iterable
 }

--- a/lib/augmentGenerator.js
+++ b/lib/augmentGenerator.js
@@ -16,7 +16,6 @@ module.exports = function augmentGenerator (generator) {
         result.push(value)
       }
 
-
       return result
     }
 

--- a/lib/augmentGenerator.js
+++ b/lib/augmentGenerator.js
@@ -1,11 +1,25 @@
 module.exports = function augmentGenerator (generator) {
   return function (...args) {
-    const iterator = generator(...args)
+    const iterable = generator(...args)
 
-    iterator.take = async function () {
-      return 1
+    iterable.take = async function (count = Infinity) {
+      const result = []
+      const iterator = iterable[Symbol.asyncIterator]()
+
+      while (result.length < count) {
+        const { value, done } = await iterator.next()
+
+        if (done) {
+          break
+        }
+
+        result.push(value)
+      }
+
+
+      return result
     }
 
-    return iterator
+    return iterable
   }
 }

--- a/lib/augmentGenerator.js
+++ b/lib/augmentGenerator.js
@@ -2,18 +2,11 @@ module.exports = function augmentGenerator (generator) {
   return function (...args) {
     const iterable = generator(...args)
 
-    iterable.toArray = async function (count = Infinity) {
+    iterable.toArray = async function () {
       const result = []
-      const iterator = iterable[Symbol.asyncIterator]()
 
-      while (result.length < count) {
-        const { value, done } = await iterator.next()
-
-        if (done) {
-          break
-        }
-
-        result.push(value)
+      for await (const v of iterable) {
+        result.push(v)
       }
 
       return result

--- a/test/index.js
+++ b/test/index.js
@@ -91,7 +91,7 @@ test('List returns an Augmented iterable', async t => {
   })
 
   const canvas = SpecialCanvas('http://example.com')
-  const result = await canvas.list('/something').take()
+  const result = await canvas.list('/something').toArray()
 
   t.deepEqual(result, [1, 2, 3, 4, 5])
 })

--- a/test/index.js
+++ b/test/index.js
@@ -72,6 +72,30 @@ test('List returns a correct iterable', async t => {
   t.deepEqual(result, [1, 2, 3, 4, 5])
 })
 
+test('List returns an Augmented iterable', async t => {
+  const SpecialCanvas = proxyquire('../index', {
+    'request-promise': function ({ url }) {
+      if (url === 'http://example.com/something') {
+        return {
+          body: [1, 2, 3],
+          headers: {
+            link: '<http://example.com/something_else>; rel="next", <irrelevant>; rel="first"'
+          }
+        }
+      } else if (url === 'http://example.com/something_else') {
+        return {
+          body: [4, 5]
+        }
+      }
+    }
+  })
+
+  const canvas = SpecialCanvas('http://example.com')
+  const result = await canvas.list('/something').take()
+
+  t.deepEqual(result, [1, 2, 3, 4, 5])
+})
+
 test('List ignores non-"rel=next" link headers', async t => {
   const SpecialCanvas = proxyquire('../index', {
     'request-promise': function ({ url }) {

--- a/test/lib.js
+++ b/test/lib.js
@@ -1,0 +1,24 @@
+const test = require('ava')
+const augmentGenerator = require('../lib/augmentGenerator')
+
+test('augmentGenerator does not mutate the original generator', t => {
+  function * gen () {
+    yield 1
+  }
+
+  augmentGenerator(gen())
+
+  t.falsy(gen().take)
+})
+
+test('augmentGenerator returns a valid generator', t => {
+  function * gen () {
+    yield 1
+  }
+
+  const g2 = augmentGenerator(gen)
+
+  for (const v of g2()) {
+    t.is(v, 1)
+  }
+})

--- a/test/lib.js
+++ b/test/lib.js
@@ -2,7 +2,7 @@ const test = require('ava')
 const augmentGenerator = require('../lib/augmentGenerator')
 
 test('augmentGenerator does not mutate the original generator', t => {
-  function * gen () {
+  async function * gen () {
     yield 1
   }
 
@@ -11,14 +11,24 @@ test('augmentGenerator does not mutate the original generator', t => {
   t.falsy(gen().take)
 })
 
-test('augmentGenerator returns a valid generator', t => {
-  function * gen () {
+test('augmentGenerator returns a valid generator', async t => {
+  async function * gen () {
     yield 1
   }
 
   const g2 = augmentGenerator(gen)
 
-  for (const v of g2()) {
+  for await (const v of g2()) {
     t.is(v, 1)
   }
+})
+
+test('AugmentedIterator.take works without arguments', async t => {
+  const gen = augmentGenerator(async function * () {
+    yield 1
+    yield 2
+    yield 3
+  })
+
+  t.deepEqual(await gen().take(), [1, 2, 3])
 })

--- a/test/lib.js
+++ b/test/lib.js
@@ -8,7 +8,7 @@ test('augmentGenerator does not mutate the original generator', t => {
 
   augmentGenerator(gen())
 
-  t.falsy(gen().take)
+  t.falsy(gen().toArray)
 })
 
 test('augmentGenerator returns a valid generator', async t => {
@@ -23,12 +23,12 @@ test('augmentGenerator returns a valid generator', async t => {
   }
 })
 
-test('AugmentedIterator.take works without arguments', async t => {
+test('AugmentedIterator.toArray works without arguments', async t => {
   const gen = augmentGenerator(async function * () {
     yield 1
     yield 2
     yield 3
   })
 
-  t.deepEqual(await gen().take(), [1, 2, 3])
+  t.deepEqual(await gen().toArray(), [1, 2, 3])
 })

--- a/test/lib.js
+++ b/test/lib.js
@@ -32,3 +32,16 @@ test('AugmentedIterator.toArray works without arguments', async t => {
 
   t.deepEqual(await gen().toArray(), [1, 2, 3])
 })
+
+test('AugmentedIterator.toArray does not restart the iteration', async t => {
+  const gen = augmentGenerator(async function * () {
+    yield 1
+    yield 2
+    yield 3
+  })
+
+  const it = gen()
+
+  await it.next()
+  t.deepEqual(await it.toArray(), [2, 3])
+})


### PR DESCRIPTION
Regular iterables (current usage that still works)

```js
for await (const course of canvas.list('/courses') {
}
```

And convert to array:

```js
const ff = (await canvas.list('/courses').toArray())
  .filter(c => c.id < 100)
```