### PR TITLE
More descriptive errors and warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = (apiUrl, apiKey, options = {}) => {
   async function * list (endpoint, queryParams = {}) {
     for await (const page of listPaginated(endpoint, queryParams)) {
       Joi.assert(page, Joi.array(), `The function ".list()" should be used with endpoints that return arrays. Use "get()" instead with the endpoint ${endpoint}.`)
-      
+
       log(`Traversing a page...`)
 
       for (const element of page) {

--- a/index.js
+++ b/index.js
@@ -29,6 +29,10 @@ module.exports = (apiUrl, apiKey, options = {}) => {
   async function requestUrl (endpoint, method = 'GET', body = {}, options = {}) {
     log(`Request ${method} ${endpoint}`)
 
+    if (method === 'GET') {
+      process.emitWarning('requestUrl() with "GET" methods is deprecated. Use get(), list() or listPaginated(). Use', 'DeprecationWarning')
+    }
+
     try {
       const result = await canvasGot({
         baseUrl: apiUrl,

--- a/index.js
+++ b/index.js
@@ -50,12 +50,17 @@ module.exports = (apiUrl, apiKey, options = {}) => {
   }
 
   async function get (endpoint, queryParams = {}) {
-    return canvasGot({
-      url: endpoint,
-      baseUrl: apiUrl,
-      method: 'GET',
-      query: queryString.stringify(queryParams, { arrayFormat: 'bracket' })
-    })
+    try {
+      const result = await canvasGot({
+        url: endpoint,
+        baseUrl: apiUrl,
+        method: 'GET',
+        query: queryString.stringify(queryParams, { arrayFormat: 'bracket' })
+      })
+      return result
+    } catch (err) {
+      throw removeToken(err)
+    }
   }
 
   async function * list (endpoint, queryParams = {}) {

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = (apiUrl, apiKey, options = {}) => {
     log(`Request ${method} ${endpoint}`)
 
     if (method === 'GET') {
-      process.emitWarning('requestUrl() with "GET" methods is deprecated. Use get(), list() or listPaginated(). Use', 'DeprecationWarning')
+      process.emitWarning('requestUrl() with "GET" methods is deprecated. Use get(), list() or listPaginated() instead.', 'DeprecationWarning')
     }
 
     try {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const got = require('got')
 const queryString = require('query-string')
 const augmentGenerator = require('./lib/augmentGenerator')
+const Joi = require('@hapi/joi')
 
 function removeToken (err) {
   delete err.gotOptions
@@ -55,6 +56,8 @@ module.exports = (apiUrl, apiKey, options = {}) => {
 
   async function * list (endpoint, queryParams = {}) {
     for await (let page of listPaginated(endpoint, queryParams)) {
+      Joi.assert(page, Joi.array(), `The function ".list()" should be used with endpoints that return arrays. Use "get()" instead with the endpoint ${endpoint}.`)
+
       log(`Traversing a page...`)
 
       for (let element of page) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -376,6 +376,47 @@
         }
       }
     },
+    "@hapi/address": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
+      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+    },
+    "@hapi/hoek": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+      "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+    },
+    "@hapi/joi": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
+      "integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/marker": "1.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/marker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
+      "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
+    },
+    "@hapi/topo": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz",
+      "integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.0.2.tgz",
+          "integrity": "sha512-O6o6mrV4P65vVccxymuruucb+GhP2zl9NLCG8OdoFRS8BEGw3vwpPp20wpAtpbQQxz1CEUtmxJGgWhjq1XA3qw=="
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "emilsten@kth.se",
   "license": "MIT",
   "dependencies": {
+    "@hapi/joi": "^15.1.0",
     "got": "^9.6.0",
     "query-string": "^6.5.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ test('Token is correctly stripped', async t => {
   const canvas = Canvas('https://kth.test.instructure.com/api/v1', 'My token')
 
   try {
-    await canvas.requestUrl('/accounts')
+    await canvas.get('/accounts')
   } catch (err) {
     const error = JSON.stringify(err)
     t.notRegex(error, /My token/)

--- a/test/index.js
+++ b/test/index.js
@@ -112,3 +112,16 @@ test('List can handle pagination urls with query strings', async t => {
 
   t.is(result.value, 'correct')
 })
+
+test('List throws a descriptive error if the endpoint response is not an array', async t => {
+  const server = await createTestServer()
+
+  server.get('/not-a-list', (req, res) => {
+    res.send({ x: 1 })
+  })
+
+  const canvas = Canvas(server.url, '')
+  const it = canvas.list('/not-a-list')
+
+  await t.throwsAsync(() => it.next(), { name: 'ValidationError' })
+})


### PR DESCRIPTION
- Deprecates usage of `requestUrl` for "GET" requests encouraging users to use `get`, `list` or `listPaginated` instead
- Throws more descriptive error if `list()` is used to reach non-list endpoints. Before this update, an error was already thrown, but now it is more clear.

Note that this PR does NOT cause breaking changes to the API of the package