### PR TITLE
Debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,10 @@ const token = 'AAAA~XXX'
 const canvas = Canvas(url, token)
 ```
 
-The builder function accepts three arguments:
+The builder function accepts two arguments:
 
 1. `url`. The root URL of the Canvas API
 2. `token`. A token obtained from Canvas to make API requests
-3. `options`. *optional* An object containing:
-   - `log`. A function that will be called with logging messages. Default: empty function
 
 ### Get a single resource with `get()`
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const got = require('got')
 const queryString = require('query-string')
 const augmentGenerator = require('./lib/augmentGenerator')
 const Joi = require('@hapi/joi')
+const debug = require('debug')('canvas-api')
 
 function removeToken (err) {
   delete err.gotOptions
@@ -17,6 +18,10 @@ function getNextUrl (linkHeader) {
 }
 
 module.exports = (apiUrl, apiKey, options = {}) => {
+  if (options.log) {
+    process.emitWarning('The "log" option is deprecated. Use DEBUG=canvas-api environment variable to enable debugging (more detailed)', 'DeprecationWarning')
+  }
+
   const log = options.log || (() => {})
 
   const canvasGot = got.extend({
@@ -28,6 +33,7 @@ module.exports = (apiUrl, apiKey, options = {}) => {
 
   async function requestUrl (endpoint, method = 'GET', body = {}, options = {}) {
     log(`Request ${method} ${endpoint}`)
+    debug(`requestUrl() ${method} ${endpoint}`)
 
     if (method === 'GET') {
       process.emitWarning('requestUrl() with "GET" methods is deprecated. Use get(), list() or listPaginated() instead.', 'DeprecationWarning')
@@ -42,14 +48,17 @@ module.exports = (apiUrl, apiKey, options = {}) => {
         ...options
       })
 
+      debug(`Successful request ${method} ${endpoint} - returning`)
       log(`Response from ${method} ${endpoint}`)
       return result
     } catch (err) {
+      debug(`Error in requestUrl() ${err.name}`)
       throw removeToken(err)
     }
   }
 
   async function get (endpoint, queryParams = {}) {
+    debug(`get() ${endpoint}`)
     try {
       const result = await canvasGot({
         url: endpoint,
@@ -57,17 +66,21 @@ module.exports = (apiUrl, apiKey, options = {}) => {
         method: 'GET',
         query: queryString.stringify(queryParams, { arrayFormat: 'bracket' })
       })
+      debug(`Response from get() ${endpoint}`)
       return result
     } catch (err) {
+      debug(`Error in get() ${err.name}`)
       throw removeToken(err)
     }
   }
 
   async function * list (endpoint, queryParams = {}) {
+    debug(`list() ${endpoint}`)
     for await (let page of listPaginated(endpoint, queryParams)) {
       Joi.assert(page, Joi.array(), `The function ".list()" should be used with endpoints that return arrays. Use "get()" instead with the endpoint ${endpoint}.`)
 
-      log(`Traversing a page...`)
+      log(`list() ${endpoint}. Traversing a page...`)
+      debug(`Traversing a page`)
 
       for (let element of page) {
         yield element
@@ -76,6 +89,7 @@ module.exports = (apiUrl, apiKey, options = {}) => {
   }
 
   async function * listPaginated (endpoint, queryParams = {}) {
+    debug(`listPaginated() ${endpoint}`)
     try {
       let query = queryString.stringify(queryParams, { arrayFormat: 'bracket' })
       let first = await canvasGot.get({
@@ -84,11 +98,14 @@ module.exports = (apiUrl, apiKey, options = {}) => {
         baseUrl: apiUrl
       })
 
+      debug(`listPaginated() ${endpoint} - Yielding first page`)
+
       yield first.body
       let url = first.headers && first.headers.link && getNextUrl(first.headers.link)
 
       while (url) {
         log(`Request GET ${url}`)
+        debug(`listPaginated() ${endpoint} - Requesting ${url}`)
 
         const response = await canvasGot.get({ url })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1039,6 +1039,15 @@
         "type-is": "~1.6.17"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "qs": {
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
@@ -1605,12 +1614,18 @@
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "debug-log": {
@@ -2055,6 +2070,17 @@
       "requires": {
         "debug": "^2.6.9",
         "resolve": "^1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-module-utils": {
@@ -2067,6 +2093,15 @@
         "pkg-dir": "^2.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -2149,6 +2184,15 @@
         "resolve": "^1.6.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -2487,6 +2531,15 @@
           "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
           "dev": true
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "http-errors": {
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -2635,6 +2688,15 @@
         "unpipe": "~1.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -4563,6 +4625,15 @@
         "statuses": "~1.4.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "http-errors": {
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@hapi/joi": "^15.1.0",
+    "debug": "^4.1.1",
     "got": "^9.6.0",
     "query-string": "^6.5.0"
   },


### PR DESCRIPTION
For getting detailed debug errors, users should use the environmental variable `DEBUG`, which is a community-accepted standard (e.g. the package `express` uses this method).

The package encourages the usage of that method of debugging instead of passing a `log` function as an option parameter. Hence, the `log` option is now deprecated