### PR TITLE
ESModules & TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Once you build a canvas instance, you get an object with only four methods:
 
 ``` js
 const Canvas = require('kth-canvas-api')
+// You can alternatively use ES modules
+import Canvas from '@kth/canvas-api/esm'
 
 const url = 'https://xxx.instructure.com/api/v1'
 const token = 'AAAA~XXX'

--- a/esm/index.d.ts
+++ b/esm/index.d.ts
@@ -1,0 +1,28 @@
+/// <reference lib="es2018" />
+
+declare interface ExtendedAsyncIterator<T> extends AsyncIterableIterator<T> {
+  /** Convert the iterator into an array (iterates through of all the elements) */
+  toArray(): Promise<Array<T>>;
+}
+
+declare interface CanvasClient {
+  /** Perform a non-get request to a canvas endpoint */
+  requestUrl(...args: any[]): any,
+
+  /** Perform a get request to a single resource */
+  get(...args: any[]): any,
+
+  /** Perform a get to an endpoint that returns a list of resources */
+  list(...args: any[]): ExtendedAsyncIterator<number>,
+
+  /** Perform a get request to an endpoint that returns list of resources. */
+  listPaginated(...args: any[]): ExtendedAsyncIterator<any>
+}
+
+/**
+ * Create a Canvas Client
+ * @param apiUrl Canvas API base URI
+ * @param apiToken Token generated in Canvas
+ * @param options Options
+ */
+export default function Canvas(apiUrl: string, apiToken: string, options: any): CanvasClient;

--- a/esm/index.mjs
+++ b/esm/index.mjs
@@ -1,0 +1,2 @@
+import Canvas from '../index.js'
+export default Canvas

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,29 @@
+/// <reference lib="es2018" />
+
+declare interface ExtendedAsyncIterator<T> extends AsyncIterableIterator<T> {
+  /** Convert the iterator into an array (iterates through of all the elements) */
+  toArray(): Promise<Array<T>>
+}
+
+declare interface CanvasClient {
+  /** Perform a non-get request to a canvas endpoint */
+  requestUrl(...args: any[]): any;
+
+  /** Perform a get request to a single resource */
+  get(...args: any[]): any;
+
+  /** Perform a get to an endpoint that returns a list of resources */
+  list(...args: any[]): ExtendedAsyncIterator<any>;
+
+  /** Perform a get request to an endpoint that returns list of resources. */
+  listPaginated(...args: any[]): ExtendedAsyncIterator<any>;
+}
+
+/**
+ * Create a Canvas Client
+ * @param apiUrl Canvas API base URI
+ * @param apiToken Token generated in Canvas
+ * @param options Options
+ */
+declare function Canvas(apiUrl: string, apiToken: string, options: any): CanvasClient;
+export = Canvas;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "test-style": "standard",
     "test": "ava"
   },
+  "exports": {
+    "./esm": "./esm/index.mjs"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/kth/canvas-api"


### PR DESCRIPTION
Enables both TypeScript and ES Modules usage (ES modules are available from Node.js 12 this October).

1. This is the way of getting CanvasAPI as ES module:

  ```js
  import CanvasAPI from '@kth/canvas-api/esm'
  ```

2. Types are also included for both ES module version and CommonJS version. Even knowing that we don't use TypeScript, this update enhances Developer Experience as it has now "hints" when using the library with an editor like VSCode. Also, the affected file is `index.d.ts` which is separated from the regular `index.js` file.