### PR TITLE
Better error handling

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,8 +2,8 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "extends": [
-    "plugin:@typescript-eslint/recommended",
-    "@kth/eslint-config-kth"
+    "@kth/eslint-config-kth",
+    "plugin:@typescript-eslint/recommended"
   ],
   "rules": {
     "import/no-extraneous-dependencies": [

--- a/README.md
+++ b/README.md
@@ -133,6 +133,36 @@ try {
 }
 ```
 
+#### Shorter error objects
+
+By default, `CanvasApiError` thrown by this library contains a property `response` with a very big object. If you would like to have a smaller `response` in the error object, you can modify the `errorHandler` property:
+
+```ts
+import CanvasApi, { minimalErrorHandler } from "@kth/canvas-api";
+const canvas = new CanvasApi("...");
+canvas.errorHandler = minimalErrorHandler;
+```
+
+#### Custom error objects
+
+You can also pass a custom function in the `.errorHandler` property: that function will be called with whatever is thrown by `got`. Read more about [errors in Got here](https://github.com/sindresorhus/got/blob/main/documentation/8-errors.md)
+
+For example:
+
+```ts
+import CanvasApi from "@kth/canvas-api";
+
+const canvas = new CanvasApi("...");
+
+canvas.errorHandler = function customHandler(err: unknown) {
+  if (err instanceof Error) {
+    console.error(err.message);
+  }
+
+  throw err;
+};
+```
+
 ## Design philosophy
 
 1. **Do not implement every endpoint**. This package does **not** implement every endpoint in Canvas API This package also does not implement type definitions for objects returned by any endpoint nor definition for parameters. That would make it unmaintainable.

--- a/README.md
+++ b/README.md
@@ -114,10 +114,8 @@ By default, this library throws `CanvasApiError` exceptions when it gets a non-2
 const canvas = new Canvas(canvasApiUrl, "-------");
 const pages = canvas.listPages("accounts/1/courses");
 
-// Now `pages` is an iterator that goes through every page
 try {
   for await (const coursesResponse of pages) {
-    // `courses` is the Response object that contains a list of courses
     const courses = coursesResponse.body;
 
     for (const course of courses) {
@@ -147,16 +145,21 @@ canvas.errorHandler = minimalErrorHandler;
 
 You can also pass a custom function in the `.errorHandler` property: that function will be called with whatever is thrown by `got`. Read more about [errors in Got here](https://github.com/sindresorhus/got/blob/main/documentation/8-errors.md)
 
-For example:
+Notes:
+
+- Argument `err` in the custom handler will be the error thrown by `got`, so it will never be `CanvasApiError`
+- Make sure the function you pass never returns something.
+
+You can use this function to create your own error objects:
 
 ```ts
 import CanvasApi from "@kth/canvas-api";
 
 const canvas = new CanvasApi("...");
 
-canvas.errorHandler = function customHandler(err: unknown) {
-  if (err instanceof Error) {
-    console.error(err.message);
+canvas.errorHandler = function customHandler(err: unknown): never {
+  if (err instanceof HTTPError) {
+    throw new CustomError(`Oh! An error! ${err.message}`);
   }
 
   throw err;

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,8 +54,7 @@ export function minimalErrorHandler(err: unknown): never {
 export default class CanvasAPI {
   private gotClient: Got;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public errorHandler: (err: unknown) => any;
+  public errorHandler: (err: unknown) => never;
 
   /**
    * Creates a `CanvasAPI` instance
@@ -198,22 +197,26 @@ export default class CanvasAPI {
     options: OptionsOfJSONResponseBody = {}
   ): AsyncGenerator<Response<T>> {
     try {
-      const first = await this.gotClient.get<T>(endpoint, {
-        searchParams: queryString.stringify(queryParams, {
-          arrayFormat: "bracket",
-        }),
-        ...options,
-      });
+      const first = await this.gotClient
+        .get<T>(endpoint, {
+          searchParams: queryString.stringify(queryParams, {
+            arrayFormat: "bracket",
+          }),
+          ...options,
+        })
+        .catch(this.errorHandler);
 
       yield first;
       let url = first.headers.link && getNextUrl(first.headers.link);
 
       while (url) {
         // eslint-disable-next-line no-await-in-loop
-        const response = await this.gotClient.get<T>(url, {
-          prefixUrl: "",
-          ...options,
-        });
+        const response = await this.gotClient
+          .get<T>(url, {
+            prefixUrl: "",
+            ...options,
+          })
+          .catch(this.errorHandler);
 
         yield response;
         url = response.headers.link && getNextUrl(response.headers.link);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,7 @@ export class CanvasApiError extends Error {
     statusMessage?: string;
   };
 
-  public code?: number;
+  public code: number;
 
   constructor(gotError: HTTPError) {
     super(gotError.message);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { Headers, HTTPError } from "got";
+import { Headers, HTTPError, Method } from "got";
 
 /**
  * Special AsyncGenerator that has a convinient "toArray()" method
@@ -31,6 +31,7 @@ export class CanvasApiError extends Error {
   public options?: {
     headers: Headers;
     url: string;
+    method: Method;
   };
 
   public response?: {
@@ -48,8 +49,9 @@ export class CanvasApiError extends Error {
     this.options = {
       headers: gotError.options.headers,
       url: gotError.options.url.toString(),
+      method: gotError.options.method,
     };
-    this.response = gotError.response;
+
     this.options.headers.authorization = "[HIDDEN]";
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,11 +43,11 @@ export class CanvasApiError extends Error {
     statusMessage?: string;
   };
 
-  public code?: string;
+  public code?: number;
 
   constructor(gotError: HTTPError) {
     super(gotError.message);
-    this.code = gotError.code;
+    this.code = gotError.response.statusCode;
     this.name = "CanvasApiError";
     this.options = {
       headers: gotError.options.headers,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,6 +51,7 @@ export class CanvasApiError extends Error {
       url: gotError.options.url.toString(),
       method: gotError.options.method,
     };
+    this.response = gotError.response;
 
     this.options.headers.authorization = "[HIDDEN]";
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,8 +43,11 @@ export class CanvasApiError extends Error {
     statusMessage?: string;
   };
 
+  public code?: string;
+
   constructor(gotError: HTTPError) {
     super(gotError.message);
+    this.code = gotError.code;
     this.name = "CanvasApiError";
     this.options = {
       headers: gotError.options.headers,


### PR DESCRIPTION
This PR enhances the way errors can be handled

## Shorter error objects

By default, `CanvasApiError` thrown by this library contains a property `response` with a very big object. If users would like to have a smaller `response` in the error object, they can modify the `errorHandler` property:

```ts
import CanvasApi, { minimalErrorHandler } from "@kth/canvas-api";
const canvas = new CanvasApi("...");
canvas.errorHandler = minimalErrorHandler;
```

(this shorter error objects might be the default one in the upcoming breaking version)

## Custom error objects

Users can also pass a custom function in the `.errorHandler` property: that function will be called with whatever is thrown by `got`. Read more about [errors in Got here](https://github.com/sindresorhus/got/blob/main/documentation/8-errors.md)

For example:

```ts
import CanvasApi from "@kth/canvas-api";
const canvas = new CanvasApi("...");
canvas.errorHandler = function customHandler(err: unknown) {
  if (err instanceof Error) {
    console.error(err.message);
  }
  throw err;
};
```

---

<details>
<summary>Discussion</summary>

This is a PR but it's actually an open discussion on error handling.

Problem: error objects thrown by the library (instances of `CanvasApiError`) contains too much information.

Question is: if we throw an object with less properties, is it a **breaking change**? This PR exposes two solutions "A" and "B".

- Solution A: throw `CanvasApiError` with less properties either considering it a breaking change or not
- Solution B: make sure that we don't do any breaking change (the code in this PR)

## A. Throw always a `CanvasApiError` that contains less properties.

In [src/utils.ts](https://github.com/KTH/canvas-api/blob/38cbd6096cd7ac254220b132330442b33f121a84/src/utils.ts#L52), instead of putting everything from `.response`, pick only the properties that we want:

```diff
- this.response = gotError.response;
+ this.response = {
+   body: gotError.response.body,
+   headers: gotError.response.headers,
+   ...
+ }
```

Question here is: would be this considered a **breaking change**?

- From the JavaScript perspective, perhaps. Removing properties from an object, even if the object is an Error, can be considered a breaking change
- From the TypeScript perspective, perhaps not. The property `response` is defined as follows:

  ```ts
  public response?: {
    body: unknown;
    headers: Headers;
    ip?: string;
    retryCount: number;
    statusCode: number;
    statusMessage?: string;
  };
  ```

  So if we remove the properties not defined in there, we _could_ say it is not a breaking change. We are just _fixing/cleaning an implementation that included properties not defined in the interface_

## B. Keep `CanvasApiError` as it is but offer a way to customize (code in this PR)

The idea is:

- Expose a `errorHandler` property that can be used to customize what kind of errors are thrown
- Expose a `minimalErrorHandler` function that can be used in the new `errorHandler` property

Read the changes in the README.md file to understand how to use this new `errorHandler` property

- Advantage: is not a breaking change
- Disadvantage: the code is less clean

</details>