### PR TITLE
Add rate limiting support

### DIFF
--- a/src/canvasApi.test.ts
+++ b/src/canvasApi.test.ts
@@ -4,8 +4,10 @@ import {
   setGlobalDispatcher,
   getGlobalDispatcher,
   Dispatcher,
+  Interceptable,
 } from "undici";
 import { createServer } from "node:http";
+import { CanvasApiError } from "./canvasApiError";
 
 describe("queryParameters", () => {
   it("should parse primitives parameters correctly", () => {
@@ -294,5 +296,103 @@ describe("method-level timeout", () => {
     expect(error?.name).toEqual("CanvasApiTimeoutError");
     expect(error?.stack).toMatch(/canvasApi\.test\.ts/g);
     expect(t2 - t1).toBeLessThan(120);
+  });
+});
+
+
+describe("Custom errors shouldn't include CanvasApi in stack trace", () => {
+  let mockPool: Interceptable;
+
+  beforeEach(() => {
+    const mockAgent = new MockAgent();
+    setGlobalDispatcher(mockAgent);
+
+    mockPool = mockAgent.get("https://canvas.local");
+  });
+
+
+  it(".get CanvasApiResponseError", async () => {
+    mockPool
+      .intercept({ path: "/call-get", method: "GET" })
+      .reply(400, '{"message": "400 error"}');
+
+    const canvas = new CanvasApi("https://canvas.local/", "");
+    const error = await canvas.get("call-get").catch((e) => e);
+
+    const stackRows = error.stack.split("\n");
+    expect(error?.name).toEqual("CanvasApiResponseError");
+    expect(stackRows[0]).toContain(`${error.name}: ${error.message}`);
+    expect(stackRows[1]).toContain(__filename);
+  });
+
+  it(".listPages CanvasApiResponseError", async () => {
+    mockPool
+      .intercept({ path: "/call-list-pages", method: "GET" })
+      .reply(400, '{"message": "400 error"}');
+
+    const canvas = new CanvasApi("https://canvas.local/", "");
+    let error = undefined;
+    try {
+      for await (const page of canvas.listPages("call-list-pages")) {
+        // Do nothing, it should throw an error
+      }
+    } catch (e: any) {
+      error = e;
+    }
+
+    const stackRows = error.stack.split("\n");
+    expect(error.name).toEqual("CanvasApiResponseError");
+    expect(stackRows[0]).toContain(`${error.name}: ${error.message}`);
+    expect(stackRows[1]).toContain(__filename);
+  });
+
+  it(".listItems CanvasApiResponseError", async () => {
+    mockPool
+      .intercept({ path: "/call-list-items", method: "GET" })
+      .reply(400, '{"message": "400 error"}');
+
+    const canvas = new CanvasApi("https://canvas.local/", "");
+    let error = undefined;
+    try {
+      for await (const page of canvas.listItems("call-list-items")) {
+        // Do nothing, it should throw an error
+      }
+    } catch (e: any) {
+      error = e;
+    }
+
+    const stackRows = error.stack.split("\n");
+    expect(error.name).toEqual("CanvasApiResponseError");
+    expect(stackRows[0]).toContain(`${error.name}: ${error.message}`);
+    expect(stackRows[1]).toContain(__filename);
+  });
+
+  it(".request CanvasApiResponseError", async () => {
+    mockPool
+      .intercept({ path: "/call-request", method: "POST" })
+      .reply(400, '{"message": "400 error"}');
+
+    const canvas = new CanvasApi("https://canvas.local/", "");
+    const error = await canvas.request("call-request", "POST").catch((e) => e);
+
+    const stackRows = error.stack.split("\n");
+    expect(error?.name).toEqual("CanvasApiResponseError");
+    expect(stackRows[0]).toContain(`${error.name}: ${error.message}`);
+    expect(stackRows[1]).toContain(__filename);
+  });
+
+  it(".sisImport CanvasApiResponseError", async () => {
+    mockPool
+      .intercept({ path: "/accounts/1/sis_imports", method: "POST" })
+      .reply(400, '{"message": "400 error"}');
+
+    const fakeFile = new File([], 'empty.txt', { type: 'text/plain' });
+    const canvas = new CanvasApi("https://canvas.local/", "");
+    const error = await canvas.sisImport(fakeFile).catch((e) => e);
+
+    const stackRows = error.stack.split("\n");
+    expect(error?.name).toEqual("CanvasApiResponseError");
+    expect(stackRows[0]).toContain(`${error.name}: ${error.message}`);
+    expect(stackRows[1]).toContain(__filename);
   });
 });

--- a/src/canvasApiError.ts
+++ b/src/canvasApiError.ts
@@ -66,7 +66,8 @@ export class CanvasApiPaginationError extends CanvasApiError {
   }
 }
 
-export function getSlimStackTrace(fnCaller: Function) {
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function getSlimStackTrace(fnCaller: (...args: any[]) => any) {
   // We capture the stack trace here so we can hide the internals of this lib thus
   // making it point directly to the business logic for operational errors.
   const tmpErr = { stack: undefined };

--- a/src/canvasApiError.ts
+++ b/src/canvasApiError.ts
@@ -17,10 +17,13 @@ export class CanvasApiResponseError extends CanvasApiError {
    * Note: this constructor does not parse the body in `response`.
    * Use {@link CanvasAPIResponseError.fromResponse} instead
    */
-  constructor() {
+  constructor(stack: string | undefined, response = new CanvasApiResponse()) {
     super("Canvas API response error");
     this.name = "CanvasApiResponseError";
-    this.response = new CanvasApiResponse();
+    if (stack !== undefined) {
+      this.stack = stack.replace("Error", `${this.name}: ${this.message}`);
+    }
+    this.response = response;
   }
 }
 
@@ -28,31 +31,45 @@ export class CanvasApiResponseError extends CanvasApiError {
  * Thrown when there was some error before reaching Canvas
  */
 export class CanvasApiConnectionError extends CanvasApiError {
-  constructor() {
+  constructor(stack?: string | undefined) {
     // TODO
     super(
       "Canvas API Connection Error: some error happen before reaching Canvas API"
     );
     this.name = "CanvasApiConnectionError";
+    if (stack !== undefined) {
+      this.stack = stack.replace("Error", `${this.name}: ${this.message}`);
+    }
   }
 }
 
 /** Thrown when a request times out before getting any response */
 export class CanvasApiTimeoutError extends CanvasApiError {
-  constructor() {
+  constructor(stack?: string | undefined) {
     super("Canvas API timeout error");
     this.name = "CanvasApiTimeoutError";
+    if (stack !== undefined) {
+      this.stack = stack.replace("Error", `${this.name}: ${this.message}`);
+    }
   }
 }
 
 export class CanvasApiPaginationError extends CanvasApiError {
   response: CanvasApiResponse;
 
-  constructor(response: CanvasApiResponse) {
+  constructor(stack: string | undefined, response: CanvasApiResponse) {
     super(
       "This endpoint did not responded with a list. Use `listPages` or `get` instead"
     );
     this.response = response;
     this.name = "CanvasApiPaginationError";
   }
+}
+
+export function getSlimStackTrace(fnCaller: Function) {
+  // We capture the stack trace here so we can hide the internals of this lib thus
+  // making it point directly to the business logic for operational errors.
+  const tmpErr = { stack: undefined };
+  Error.captureStackTrace(tmpErr, fnCaller);
+  return tmpErr.stack;
 }

--- a/src/rateLimiter.test.ts
+++ b/src/rateLimiter.test.ts
@@ -1,0 +1,48 @@
+import { performance } from "perf_hooks";
+import { CanvasApi } from "./canvasApi";
+import { MockAgent, setGlobalDispatcher, Interceptable } from "undici";
+
+describe("Rate limiter works", () => {
+  let mockPool: Interceptable;
+
+  beforeEach(() => {
+    const mockAgent = new MockAgent();
+    setGlobalDispatcher(mockAgent);
+
+    mockPool = mockAgent.get("https://canvas.local");
+  });
+
+  it("and retries when limit period has reset", async () => {
+    mockPool
+      .intercept({ path: "/call", method: "GET" })
+      .reply(403, "403 Forbidden (Rate Limit Exceeded)");
+
+    mockPool
+      .intercept({ path: "/call", method: "GET" })
+      .reply(200, '{"msg": "ok"}');
+
+    const canvas = new CanvasApi("https://canvas.local/", "");
+
+    const start = performance.now();
+    const res = await canvas.get("call");
+    const end = performance.now();
+
+    expect(res.json.msg).toEqual("ok");
+    // The reset is evert 1000ms nad calls are resolved locally
+    expect(end - start).toBeGreaterThan(900);
+    expect(end - start).toBeLessThan(1100);
+  });
+
+  it("doesn't consume regular 403 body", async () => {
+    mockPool
+      .intercept({ path: "/forbidden", method: "GET" })
+      .reply(403, "403 Forbidden (Permissions)");
+
+    const canvas = new CanvasApi("https://canvas.local/", "");
+
+    const err = await canvas.get("forbidden").catch((e) => e);
+
+    expect(err.response.statusCode).toEqual(403);
+    expect(err.response.text).toEqual("403 Forbidden (Permissions)");
+  });
+});

--- a/src/rateLimiter.ts
+++ b/src/rateLimiter.ts
@@ -1,0 +1,147 @@
+import { URL, UrlObject } from "url";
+import { request as _request } from "undici";
+import type { Dispatcher } from "undici";
+
+type TRateLimitWorkItem = [
+  (value: Dispatcher.ResponseData) => void,
+  (err: unknown) => void,
+  () => Promise<Dispatcher.ResponseData>,
+  number
+];
+
+type TReadOnlyRateLimiterFactoryOptions = {
+  limitIntervalMs: number;
+};
+
+export function rateLimitedRequestFactory({
+  limitIntervalMs,
+}: TReadOnlyRateLimiterFactoryOptions) {
+  const _pendingWorkItems: TRateLimitWorkItem[] = [];
+  let _callCounter = 0;
+  let _isIdle = true;
+  let _nextDelay = 0;
+  let _intervalPeriodStart = 0;
+
+  const _setDelayToStartAtNextInterval = () => {
+    // Limit reached, wait until period is over
+    // TODO: Consider logging rate limit issues
+    const delta = Date.now() - _intervalPeriodStart;
+    const calcDelay = limitIntervalMs - delta;
+    if (_nextDelay < calcDelay) {
+      _nextDelay = calcDelay;
+    }
+    // console.debug(`Bouncing on rate limiter: ${delta}`);
+  };
+
+  const _checkAndResetInterval = () => {
+    const delta = Date.now() - _intervalPeriodStart;
+
+    if (delta > limitIntervalMs) {
+      // Reset interval every 1000ms
+      _intervalPeriodStart = Date.now();
+      _nextDelay = 0;
+      // console.debug(`Reset limiter: ${_nextDelay} (${delta})`);
+      return;
+    }
+  };
+
+  const _getCallCounter = () => {
+    _callCounter =
+      _callCounter >= Number.MAX_SAFE_INTEGER ? 1 : _callCounter + 1;
+    return _callCounter;
+  };
+
+  const request = (
+    url: string | URL | UrlObject,
+    {
+      method,
+      headers,
+      body,
+      signal,
+    }: Omit<Dispatcher.RequestOptions, "origin" | "path" | "method"> &
+      Partial<Pick<Dispatcher.RequestOptions, "method">>
+  ): Promise<Dispatcher.ResponseData> => {
+    return new Promise((resolve, reject) => {
+      _pendingWorkItems.push([
+        resolve,
+        reject,
+        async () => await _request(url, { method, headers, body, signal }),
+        _getCallCounter(),
+      ]);
+
+      // We need to wrap the work loop in a function so we can restart it
+      // when we get 429 (rate limit) from server
+      const startWorkLoop = async () => {
+        // If the rate limiter is idle we need to start it
+        if (_isIdle) {
+          _isIdle = false;
+          _intervalPeriodStart = Date.now();
+
+          // console.debug("Work loop started...");
+          let currentWorkItem: TRateLimitWorkItem;
+          try {
+            // This is the main loop
+            while (_pendingWorkItems.length > 0) {
+              if (_nextDelay > 0) {
+                await new Promise((waitResolve) => {
+                  setTimeout(waitResolve, _nextDelay);
+                });
+              }
+              _checkAndResetInterval();
+
+              currentWorkItem = _pendingWorkItems.shift()!;
+              const [workResolve, workReject, workFn, _idCounter] =
+                currentWorkItem;
+              workFn()
+                .then(async (res: Dispatcher.ResponseData) => {
+                  if (res?.statusCode === 403) {
+                    const text = await res.body.text();
+                    if (text.includes("Rate Limit Exceeded")) {
+                      // console.debug(`...429 call ${_idCounter}, delay: ${_nextDelay}, ${Date.now() - _intervalPeriodStart}, -- ${_isIdle ? "IDLE" : "RUNNING"}`);
+                      // Return the work item to the stack for retry
+                      // WARNING: Don't use currentWorkItem, it is mutated when iterating through the while loop
+                      _pendingWorkItems.unshift([
+                        workResolve,
+                        workReject,
+                        workFn,
+                        _idCounter,
+                      ]);
+                      _setDelayToStartAtNextInterval();
+                      startWorkLoop();
+                      return;
+                    }
+
+                    // reading res.body.text() above consumes the stream so we need to add it
+                    // to allow `async parseBody(response: Dispatcher.ResponseData)` to fetch
+                    // the content
+                    res.body.text = async () => text;
+                  }
+                  // console.debug(`+++200 call ${_idCounter}, delay: ${_nextDelay}, ${Date.now() - _intervalPeriodStart}, -- ${_isIdle ? "IDLE" : "RUNNING"}`);
+                  workResolve(res);
+                })
+                .catch(workReject);
+            }
+          } catch (err) {
+            if (currentWorkItem! !== undefined) {
+              // This is a programming error specific to this call. The loop while continue
+              // to avoid weird side effects, but we need to fail this call.
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              const [_workResolve, workReject, _workFn, _idCounter] =
+                currentWorkItem;
+              workReject(currentWorkItem);
+            }
+          } finally {
+            _isIdle = true;
+            // console.debug("...work loop stopped");
+          }
+        }
+      };
+      // I am starting this after a tick to ensure that multiple calls (such as with map)
+      // are executed with a single start of the loop. This makes it more obvious that
+      // the loop is working as intended and not started from multiple places.
+      setTimeout(() => startWorkLoop(), 0);
+    });
+  };
+
+  return request;
+}


### PR DESCRIPTION
This PR is primarily focused on adding rate limiting support:

- All calls are placed in a FIFO queue as work items.
- Each work item is processed sequentially.
- If Canvas API responds with "403 Forbidden (Rate Limit Exceeded)", the processed work item will be retried once the current rate limit period has concluded (default 1000ms).

The PR also:
- reduces calls to the expensive Error.captureStackTrace
- improves stack trace for custom errors so they exclude library code