### PR TITLE
Refactor stacktrace

### DIFF
--- a/src/canvasApi.test.ts
+++ b/src/canvasApi.test.ts
@@ -399,4 +399,16 @@ describe("Custom errors shouldn't include CanvasApi in stack trace", () => {
     expect(stackRows[0]).toContain(`${error.name}: ${error.message}`);
     expect(stackRows[1]).toContain(__filename);
   });
+
+  it(".request CanvasApiRequestError with malformed request body", async () => {
+    const canvas = new CanvasApi("https://canvas.local/", "");
+    const error = await canvas
+      .request("call-request", "POST", 123n)
+      .catch((e) => e); // Can't serialize BigInt
+
+    const stackRows = error.stack.split("\n");
+    expect(error?.name).toEqual("CanvasApiRequestError");
+    expect(stackRows[0]).toContain(`${error.name}: ${error.message}`);
+    expect(stackRows[1]).toContain(__filename);
+  });
 });

--- a/src/canvasApiError.ts
+++ b/src/canvasApiError.ts
@@ -17,47 +17,40 @@ export class CanvasApiResponseError extends CanvasApiError {
    * Note: this constructor does not parse the body in `response`.
    * Use {@link CanvasAPIResponseError.fromResponse} instead
    */
-  constructor(stack: string | undefined, response = new CanvasApiResponse()) {
+  constructor(response = new CanvasApiResponse()) {
     super("Canvas API response error");
     this.name = "CanvasApiResponseError";
-    if (stack !== undefined) {
-      this.stack = stack.replace("Error", `${this.name}: ${this.message}`);
-    }
     this.response = response;
   }
 }
 
 /**
- * Thrown when there was some error before reaching Canvas
+ * Thrown when there was some error with the request
  */
-export class CanvasApiConnectionError extends CanvasApiError {
-  constructor(stack?: string | undefined) {
+export class CanvasApiRequestError extends CanvasApiError {
+  constructor(message?: string) {
     // TODO
     super(
-      "Canvas API Connection Error: some error happen before reaching Canvas API"
+      `Canvas API Request Error: ${
+        message ?? "there is something wrong with your request"
+      }`
     );
-    this.name = "CanvasApiConnectionError";
-    if (stack !== undefined) {
-      this.stack = stack.replace("Error", `${this.name}: ${this.message}`);
-    }
+    this.name = "CanvasApiRequestError";
   }
 }
 
 /** Thrown when a request times out before getting any response */
 export class CanvasApiTimeoutError extends CanvasApiError {
-  constructor(stack?: string | undefined) {
+  constructor() {
     super("Canvas API timeout error");
     this.name = "CanvasApiTimeoutError";
-    if (stack !== undefined) {
-      this.stack = stack.replace("Error", `${this.name}: ${this.message}`);
-    }
   }
 }
 
 export class CanvasApiPaginationError extends CanvasApiError {
   response: CanvasApiResponse;
 
-  constructor(stack: string | undefined, response: CanvasApiResponse) {
+  constructor(response: CanvasApiResponse) {
     super(
       "This endpoint did not responded with a list. Use `listPages` or `get` instead"
     );
@@ -73,4 +66,17 @@ export function getSlimStackTrace(fnCaller: (...args: any[]) => any) {
   const tmpErr = { stack: undefined };
   Error.captureStackTrace(tmpErr, fnCaller);
   return tmpErr.stack;
+}
+
+export function canvasApiErrorDecorator(
+  error:
+    | CanvasApiPaginationError
+    | CanvasApiTimeoutError
+    | CanvasApiRequestError,
+  stack: string | undefined
+) {
+  if (stack !== undefined) {
+    error.stack = stack.replace("Error", `${error.name}: ${error.message}`);
+  }
+  return error;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,5 @@ export { CanvasApi } from "./canvasApi";
 export {
   CanvasApiError,
   CanvasApiResponseError,
-  CanvasApiConnectionError,
+  CanvasApiRequestError,
 } from "./canvasApiError";


### PR DESCRIPTION
- revert introduction of stack trace in error constructor
- improve error for request data

Breaking:
- change CanvasApiConnectionError to CanvasApiRequestError for consistency